### PR TITLE
fix(ui): correct displayed client version from v0.1.0 to v0.3.0

### DIFF
--- a/flock-ui/src/components/Settings/SystemSettings/components/SystemInfoCard.tsx
+++ b/flock-ui/src/components/Settings/SystemSettings/components/SystemInfoCard.tsx
@@ -70,7 +70,7 @@ export function SystemInfoCard({ t, workdir, dbPath }: SystemInfoCardProps) {
               </Text>
               <Text size="xs" c="dimmed">|</Text>
               <Text size="sm" fw={500}>
-                {t('systemSettings.clientVersion')}: <span style={{ fontWeight: 600 }}>v0.2.0</span>
+                {t('systemSettings.clientVersion')}: <span style={{ fontWeight: 600 }}>v0.3.0</span>
               </Text>
             </Group>
           </div>

--- a/flock-ui/src/components/Settings/SystemSettings/components/SystemInfoCard.tsx
+++ b/flock-ui/src/components/Settings/SystemSettings/components/SystemInfoCard.tsx
@@ -70,7 +70,7 @@ export function SystemInfoCard({ t, workdir, dbPath }: SystemInfoCardProps) {
               </Text>
               <Text size="xs" c="dimmed">|</Text>
               <Text size="sm" fw={500}>
-                {t('systemSettings.clientVersion')}: <span style={{ fontWeight: 600 }}>v0.1.0</span>
+                {t('systemSettings.clientVersion')}: <span style={{ fontWeight: 600 }}>v0.2.0</span>
               </Text>
             </Group>
           </div>

--- a/flock-ui/src/i18n/locales/en/settings.json
+++ b/flock-ui/src/i18n/locales/en/settings.json
@@ -16,7 +16,7 @@
     "pet": "XiaoF companion pet appearance & behavior settings"
   },
   "developing": "Developing...",
-  "version": "Flock CLI v0.2.0",
+  "version": "Flock CLI v0.3.0",
   "xiaof": {
     "saveSuccess": "XIAOF Agent configuration updated successfully",
     "loading": "Loading XIAOF agent settings...",

--- a/flock-ui/src/i18n/locales/en/settings.json
+++ b/flock-ui/src/i18n/locales/en/settings.json
@@ -16,7 +16,7 @@
     "pet": "XiaoF companion pet appearance & behavior settings"
   },
   "developing": "Developing...",
-  "version": "Flock CLI v0.1.0",
+  "version": "Flock CLI v0.2.0",
   "xiaof": {
     "saveSuccess": "XIAOF Agent configuration updated successfully",
     "loading": "Loading XIAOF agent settings...",

--- a/flock-ui/src/i18n/locales/zh/settings.json
+++ b/flock-ui/src/i18n/locales/zh/settings.json
@@ -16,7 +16,7 @@
     "pet": "XiaoF 伴侣宠物外观与行为设置"
   },
   "developing": "功能开发中...",
-  "version": "Flock CLI v0.2.0",
+  "version": "Flock CLI v0.3.0",
   "xiaof": {
     "saveSuccess": "XIAOF Agent 配置更新已生效",
     "loading": "正在加载 XIAOF 智能体设置...",

--- a/flock-ui/src/i18n/locales/zh/settings.json
+++ b/flock-ui/src/i18n/locales/zh/settings.json
@@ -16,7 +16,7 @@
     "pet": "XiaoF 伴侣宠物外观与行为设置"
   },
   "developing": "功能开发中...",
-  "version": "Flock CLI v0.1.0",
+  "version": "Flock CLI v0.2.0",
   "xiaof": {
     "saveSuccess": "XIAOF Agent 配置更新已生效",
     "loading": "正在加载 XIAOF 智能体设置...",


### PR DESCRIPTION
## Summary

The client version shown in **Settings → System** was still hardcoded as
`v0.1.0`, while the actual project version is `0.2.0` (see `Cargo.toml` and
`flock-ui/package.json`). This updates the three remaining stale references so
the displayed version matches the real build.

## Changes

- `flock-ui/src/i18n/locales/en/settings.json` — `Flock CLI v0.1.0` → `v0.2.0`
- `flock-ui/src/i18n/locales/zh/settings.json` — `Flock CLI v0.1.0` → `v0.2.0`
- `flock-ui/src/components/Settings/SystemSettings/components/SystemInfoCard.tsx` — hardcoded `v0.1.0` → `v0.2.0`

## Notes

Display-only change; no logic or behavior affected.